### PR TITLE
Minor fix in sorting, larger fix to show records beyond the first 1000 (demonstrating continuation token)

### DIFF
--- a/command_center_node/public/index.html
+++ b/command_center_node/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -130,9 +130,9 @@
                                 temperature: x.temperaturereading._,
                                 eventtime: d
                             });
-                            $scope.temperatures.reverse();
                         }); 
-                        
+                        $scope.temperatures.reverse();
+
                         $scope.latest_reading = $scope.temperatures[0];
                     } 
                 });


### PR DESCRIPTION
The change in index.html addresses what is IMHO a sorting error.

The change in server.js allows to see the latest records on the web page when there's more than a 1000 records in the storage table. This also demonstrates the usage of the continuation token, which I think is quite relevant when using these tables. As always, one can argue about the solution chosen, I'm open for alternatives.